### PR TITLE
TaskBウィンドウが消えるバグを修正

### DIFF
--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -196,7 +196,6 @@ extern "C" void KernelMainNewStack(
   InitializeTextWindow();
   InitializeTaskBWindow();
   layer_manager->Draw({{0, 0}, ScreenSize()});
-  active_layer->Activate(task_b_window_layer_id);
 
   acpi::Initialize(acpi_table);
   InitializeLAPICTimer();
@@ -216,6 +215,7 @@ extern "C" void KernelMainNewStack(
   usb::xhci::Initialize();
   InitializeKeyboard();
   InitializeMouse();
+  active_layer->Activate(task_b_window_layer_id);
 
   char str[128];
 


### PR DESCRIPTION
15.2 アクティブウィンドウ（osbook_day15bのソース）でTaskBウィンドウが一瞬表示された後に消えてしまい、以降操作できない現象が生じました。

これはTaskBをアクティベイトした位置ではまだマウスレイヤーが作成されておらず、ActiveLayerのmouse_layer_も設定されていないため、mouse_layer_の値が初期値の0であり、アクティベイトしたことでTaskBのレイヤー上の位置が-1になったためと思われます。

TaskBのアクティベイトをInitializeMouse()の後に移動することでこの現象は消えました。