### PR TITLE
タイポの修正、ログ文言の修正、エラーコードの並び順誤りの修正、printf-like関数の呼び出し誤りの修正

### DIFF
--- a/MikanLoaderPkg/Main.c
+++ b/MikanLoaderPkg/Main.c
@@ -340,7 +340,7 @@ EFI_STATUS EFIAPI UefiMain(
   VOID* kernel_buffer;
   status = ReadFile(kernel_file, &kernel_buffer);
   if (EFI_ERROR(status)) {
-    Print(L"error: %r", status);
+    Print(L"error: %r\n", status);
     Halt();
   }
 
@@ -374,7 +374,7 @@ EFI_STATUS EFIAPI UefiMain(
   if (status == EFI_SUCCESS) {
     status = ReadFile(volume_file, &volume_image);
     if (EFI_ERROR(status)) {
-      Print(L"failed to read volume file: %r", status);
+      Print(L"failed to read volume file: %r\n", status);
       Halt();
     }
   } else {

--- a/kernel/error.hpp
+++ b/kernel/error.hpp
@@ -69,8 +69,8 @@ class Error {
     "kInvalidFile",
     "kIsDirectory",
     "kNoSuchEntry",
-    "kEndpointNotInCharge",
     "kFreeTypeError",
+    "kEndpointNotInCharge",
   };
   static_assert(Error::Code::kLastOfCode == code_names_.size());
 

--- a/kernel/file.hpp
+++ b/kernel/file.hpp
@@ -15,5 +15,5 @@ class FileDescriptor {
   virtual size_t Load(void* buf, size_t len, size_t offset) = 0;
 };
 
-size_t PrintToFD(FileDescriptor& fd, const char* format, ...);
+size_t PrintToFD(FileDescriptor& fd, const char* format, ...) __attribute__((format(printf, 2, 3)));
 size_t ReadDelim(FileDescriptor& fd, char delim, char* buf, size_t len);

--- a/kernel/file.hpp
+++ b/kernel/file.hpp
@@ -15,5 +15,6 @@ class FileDescriptor {
   virtual size_t Load(void* buf, size_t len, size_t offset) = 0;
 };
 
-size_t PrintToFD(FileDescriptor& fd, const char* format, ...) __attribute__((format(printf, 2, 3)));
+size_t PrintToFD(FileDescriptor& fd, const char* format, ...)
+    __attribute__((format(printf, 2, 3)));
 size_t ReadDelim(FileDescriptor& fd, char delim, char* buf, size_t len);

--- a/kernel/font.cpp
+++ b/kernel/font.cpp
@@ -193,7 +193,7 @@ void InitializeFont() {
   nihongo_buf = new std::vector<uint8_t>(size);
   if (LoadFile(nihongo_buf->data(), size, *entry) != size) {
     delete nihongo_buf;
-    Log(kError, "failedto load nihongo.ttf");
+    Log(kError, "failed to load nihongo.ttf");
     exit(1);
   }
 }

--- a/kernel/libcxx_support.cpp
+++ b/kernel/libcxx_support.cpp
@@ -1,7 +1,7 @@
 #include <new>
 #include <cerrno>
 
-int printk(const char* format, ...);
+ __attribute__((format(printf, 1, 2))) int printk(const char* format, ...);
 
 std::new_handler std::get_new_handler() noexcept {
   return [] {

--- a/kernel/libcxx_support.cpp
+++ b/kernel/libcxx_support.cpp
@@ -1,7 +1,8 @@
 #include <new>
 #include <cerrno>
 
- __attribute__((format(printf, 1, 2))) int printk(const char* format, ...);
+int printk(const char* format, ...)
+    __attribute__((format(printf, 1, 2)));
 
 std::new_handler std::get_new_handler() noexcept {
   return [] {

--- a/kernel/logger.hpp
+++ b/kernel/logger.hpp
@@ -28,4 +28,4 @@ void SetLogLevel(enum LogLevel level);
  * @param level  ログの優先度．しきい値以上の優先度のログのみが記録される．
  * @param format  書式文字列．printk と互換．
  */
-int Log(enum LogLevel level, const char* format, ...);
+int Log(enum LogLevel level, const char* format, ...)  __attribute__((format(printf, 2, 3)));

--- a/kernel/logger.hpp
+++ b/kernel/logger.hpp
@@ -28,4 +28,5 @@ void SetLogLevel(enum LogLevel level);
  * @param level  ログの優先度．しきい値以上の優先度のログのみが記録される．
  * @param format  書式文字列．printk と互換．
  */
-int Log(enum LogLevel level, const char* format, ...)  __attribute__((format(printf, 2, 3)));
+int Log(enum LogLevel level, const char* format, ...)
+    __attribute__((format(printf, 2, 3)));

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -39,7 +39,7 @@
 #include "syscall.hpp"
 #include "uefi.hpp"
 
- __attribute__((format(printf, 1, 2)))int printk(const char* format, ...) {
+__attribute__((format(printf, 1, 2))) int printk(const char* format, ...) {
   va_list ap;
   int result;
   char s[1024];

--- a/kernel/main.cpp
+++ b/kernel/main.cpp
@@ -39,7 +39,7 @@
 #include "syscall.hpp"
 #include "uefi.hpp"
 
-int printk(const char* format, ...) {
+ __attribute__((format(printf, 1, 2)))int printk(const char* format, ...) {
   va_list ap;
   int result;
   char s[1024];

--- a/kernel/pci.cpp
+++ b/kernel/pci.cpp
@@ -330,8 +330,9 @@ void InitializePCI() {
     const auto& dev = pci::devices[i];
     auto vendor_id = pci::ReadVendorId(dev);
     auto class_code = pci::ReadClassCode(dev.bus, dev.device, dev.function);
-    Log(kDebug, "%d.%d.%d: vend %04x, class %08x, head %02x\n",
+    Log(kDebug, "%d.%d.%d: vend %04x, class %02x.%02x.%02x, head %02x\n",
         dev.bus, dev.device, dev.function,
-        vendor_id, class_code, dev.header_type);
+        vendor_id, class_code.base, class_code.sub, class_code.interface,
+        dev.header_type);
   }
 }

--- a/kernel/usb/classdriver/hid.cpp
+++ b/kernel/usb/classdriver/hid.cpp
@@ -42,8 +42,8 @@ namespace usb {
 
   Error HIDBaseDriver::OnControlCompleted(EndpointID ep_id, SetupData setup_data,
                                           const void* buf, int len) {
-    Log(kDebug, "HIDBaseDriver::OnControlCompleted: dev %08x, phase = %d, len = %d\n",
-        this, initialize_phase_, len);
+    Log(kDebug, "HIDBaseDriver::OnControlCompleted: dev %08lx, phase = %d, len = %d\n",
+        reinterpret_cast<uintptr_t>(this), initialize_phase_, len);
     if (initialize_phase_ == 1) {
       initialize_phase_ = 2;
       return ParentDevice()->NormalIn(ep_interrupt_in_, buf_.data(), in_packet_size_);

--- a/kernel/usb/device.cpp
+++ b/kernel/usb/device.cpp
@@ -190,8 +190,8 @@ namespace usb {
 
   Error Device::OnControlCompleted(EndpointID ep_id, SetupData setup_data,
                                    const void* buf, int len) {
-    Log(kDebug, "Device::OnControlCompleted: buf 0x%08x, len %d, dir %d\n",
-        buf, len, setup_data.request_type.bits.direction);
+    Log(kDebug, "Device::OnControlCompleted: buf 0x%08lx, len %d, dir %d\n",
+        reinterpret_cast<uintptr_t>(buf), len, setup_data.request_type.bits.direction);
     if (is_initialized_) {
       if (auto w = event_waiters_.Get(setup_data)) {
         return w.value()->OnControlCompleted(ep_id, setup_data, buf, len);

--- a/kernel/usb/xhci/device.cpp
+++ b/kernel/usb/xhci/device.cpp
@@ -110,8 +110,8 @@ namespace usb::xhci {
       return err;
     }
 
-    Log(kDebug, "Device::ControlIn: ep addr %d, buf 0x%08x, len %d\n",
-        ep_id.Address(), buf, len);
+    Log(kDebug, "Device::ControlIn: ep addr %d, buf 0x%08lx, len %d\n",
+        ep_id.Address(), reinterpret_cast<uintptr_t>(buf), len);
     if (ep_id.Number() < 0 || 15 < ep_id.Number()) {
       return MAKE_ERROR(Error::kInvalidEndpointNumber);
     }
@@ -157,8 +157,8 @@ namespace usb::xhci {
       return err;
     }
 
-    Log(kDebug, "Device::ControlOut: ep addr %d, buf 0x%08x, len %d\n",
-        ep_id.Address(), buf, len);
+    Log(kDebug, "Device::ControlOut: ep addr %d, buf 0x%08lx, len %d\n",
+        ep_id.Address(), reinterpret_cast<uintptr_t>(buf), len);
     if (ep_id.Number() < 0 || 15 < ep_id.Number()) {
       return MAKE_ERROR(Error::kInvalidEndpointNumber);
     }

--- a/kernel/usb/xhci/xhci.cpp
+++ b/kernel/usb/xhci/xhci.cpp
@@ -355,7 +355,7 @@ namespace {
     pci::WriteConfReg(xhc_dev, 0xd8, superspeed_ports); // USB3_PSSEN
     uint32_t ehci2xhci_ports = pci::ReadConfReg(xhc_dev, 0xd4); // XUSB2PRM
     pci::WriteConfReg(xhc_dev, 0xd0, ehci2xhci_ports); // XUSB2PR
-    Log(kDebug, "SwitchEhci2Xhci: SS = %02, xHCI = %02x\n",
+    Log(kDebug, "SwitchEhci2Xhci: SS = %02x, xHCI = %02x\n",
         superspeed_ports, ehci2xhci_ports);
   }
 } // namespace


### PR DESCRIPTION
表題の通り、細かな修正を含んでいます。
それぞれ個別の pull req を作成した方が良いということでしたら分割しますのでお申し付けください。

printf-like 関数については、 `__attribute__((format(printf, ..)))` によりコンパイル時に誤りを検出できるようにしています。
非標準機能ですが本書では clang/clang++ 8+ を利用することを前提としているため利用して問題ないと考えました。