### PR TITLE
機能追加：ブートメニューを追加

### DIFF
--- a/MikanLoaderPkg/Loader.inf
+++ b/MikanLoaderPkg/Loader.inf
@@ -10,6 +10,7 @@
 
 [Sources]
   Main.c
+  menu.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MikanLoaderPkg/Main.c
+++ b/MikanLoaderPkg/Main.c
@@ -12,8 +12,8 @@
 #include  <Guid/FileInfo.h>
 #include  "frame_buffer_config.hpp"
 #include  "memory_map.hpp"
-#include "elf.hpp"
-#include "menu.h"
+#include  "elf.hpp"
+#include  "menu.h"
 
 EFI_STATUS GetMemoryMap(struct MemoryMap* map) {
   if (map->buffer == NULL) {

--- a/MikanLoaderPkg/Main.c
+++ b/MikanLoaderPkg/Main.c
@@ -270,25 +270,9 @@ EFI_STATUS EFIAPI UefiMain(
     EFI_SYSTEM_TABLE* system_table) {
   EFI_STATUS status;
 
+  /* Print(L"Hello, Mikan World!\n"); */
+  boot_menu();
 
-  Print(L"Hello, Mikan World!\n");
-
-  /* 改変箇所 */
-  gST->BootServices->SetWatchdogTimer(0, 0, 0, NULL);
-  boot_menu_print();
-  /* ぽーりんぐのテスト */
-  EFI_INPUT_KEY key = {0, 0};
-      key = poling_key();
-      Print(L"%c", key.UnicodeChar);
-
-  while (1) {
-      /* Halt(); */
-            key = poling_key();
-      Print(L"%c", key.UnicodeChar);
-          }
-  
-
-  
   CHAR8 memmap_buf[4096 * 4];
   struct MemoryMap memmap = {sizeof(memmap_buf), memmap_buf, 0, 0, 0, 0};
   status = GetMemoryMap(&memmap);

--- a/MikanLoaderPkg/Main.c
+++ b/MikanLoaderPkg/Main.c
@@ -12,7 +12,8 @@
 #include  <Guid/FileInfo.h>
 #include  "frame_buffer_config.hpp"
 #include  "memory_map.hpp"
-#include  "elf.hpp"
+#include "elf.hpp"
+#include "menu.h"
 
 EFI_STATUS GetMemoryMap(struct MemoryMap* map) {
   if (map->buffer == NULL) {
@@ -269,8 +270,25 @@ EFI_STATUS EFIAPI UefiMain(
     EFI_SYSTEM_TABLE* system_table) {
   EFI_STATUS status;
 
+
   Print(L"Hello, Mikan World!\n");
 
+  /* 改変箇所 */
+  gST->BootServices->SetWatchdogTimer(0, 0, 0, NULL);
+  boot_menu_print();
+  /* ぽーりんぐのテスト */
+  EFI_INPUT_KEY key = {0, 0};
+      key = poling_key();
+      Print(L"%c", key.UnicodeChar);
+
+  while (1) {
+      /* Halt(); */
+            key = poling_key();
+      Print(L"%c", key.UnicodeChar);
+          }
+  
+
+  
   CHAR8 memmap_buf[4096 * 4];
   struct MemoryMap memmap = {sizeof(memmap_buf), memmap_buf, 0, 0, 0, 0};
   status = GetMemoryMap(&memmap);

--- a/MikanLoaderPkg/menu.c
+++ b/MikanLoaderPkg/menu.c
@@ -3,17 +3,90 @@
 #include  <Library/UefiBootServicesTableLib.h>
 #include "menu.h"
 
-/* EFI_INPUT_KEY poling_key(); */
+EFI_INPUT_KEY poling_key();
 void logo_print(int cursor_x, int cursor_y);
 void clear();
 void menu_add(int menu_number, EFI_STRING menu_name, int menu_type);
 void set_cursor(int cursor_x, int cursor_y);
-
-
 void boot_menu();
+void print_device_information();
+void boot_menu_print();
 
+static EFI_INPUT_KEY get_key = {0, 0};
+
+/* Optionで別画面を開くには、戻ってきた時に再度boot_menu_printをすればいい。 */
 void boot_menu(){
-    boot_menu_print();
+    gST->BootServices->SetWatchdogTimer(0, 0, 0, NULL);
+    while (1) {
+        boot_menu_print();
+        get_key = poling_key();
+        switch (get_key.UnicodeChar) {
+        case '1':               /* mikanos boot */
+            clear();
+            return;
+        case '2':
+            print_device_information();
+        }
+    }
+}
+
+/*  */
+void print_device_information(){
+    EFI_INPUT_KEY exit_key = {0, 0};
+    clear();
+    Print(L"UEFI information \n");
+    Print(L"UEFI Vendor information: %s\n", gST->FirmwareVendor);
+    Print(L"UEFI Firmware version: 0x%x\n", gST->FirmwareRevision);
+    Print(L"Support UEFI Specification: UEFI");
+    switch (gST->Hdr.Revision) {
+    case EFI_1_02_SYSTEM_TABLE_REVISION:
+        Print(L" 1.02 ");
+        break;
+    case EFI_1_10_SYSTEM_TABLE_REVISION:
+        Print(L" 1.10 ");
+        break;
+    case EFI_2_00_SYSTEM_TABLE_REVISION:
+        Print(L" 2.00 ");
+        break;
+    case EFI_2_10_SYSTEM_TABLE_REVISION:
+        Print(L" 2.10 ");
+        break;
+    case EFI_2_20_SYSTEM_TABLE_REVISION:
+        Print(L" 2.20 ");
+        break;
+    case EFI_2_30_SYSTEM_TABLE_REVISION:
+        Print(L" 2.30 ");
+        break;
+    case EFI_2_31_SYSTEM_TABLE_REVISION:
+        Print(L" 2.31 ");
+        break;
+    case EFI_2_40_SYSTEM_TABLE_REVISION:
+        Print(L" 2.40 ");
+        break;
+    case EFI_2_50_SYSTEM_TABLE_REVISION:
+        Print(L" 2.50 ");
+        break;
+    case EFI_2_60_SYSTEM_TABLE_REVISION:
+        Print(L" 2.60 ");
+        break;
+    case EFI_2_70_SYSTEM_TABLE_REVISION:
+        Print(L" 2.70 ");
+        break;
+    case EFI_2_80_SYSTEM_TABLE_REVISION:
+        Print(L" 2.80 ");
+        break;
+    default:
+        Print(L"%x", gST->Hdr.Revision);
+    }
+    Print(L"supported\n");
+    set_cursor(1, 15);
+    Print(L"Return boot menu: Press q\n");
+    while (1) {
+        exit_key = poling_key();
+        if (exit_key.UnicodeChar == 'q'){
+            return;
+        }
+    }
 }
 
 /* メニューに追加を行う場合、ここに画面に表示をするメニューを描く必要があります。*/
@@ -33,13 +106,10 @@ void boot_menu_print(){
     set_cursor(5, 15);
     Print(L"Options");
     set_cursor(5, 16);
-    menu_add(2, L"UEFI information", 2);
+    menu_add(2, L"Device information", 2);
     Print(L"\n========================================\n");    
 }
 
-void set_cursor(int cursor_x, int cursor_y){
-        gST->ConOut->SetCursorPosition(gST->ConOut, cursor_x, cursor_y);
-}
 
 /* menu_typeは1がメインメニュー関連、2がOption関連 */
 /* Optionだとset_cursorをいちいちする必要があります。 */
@@ -56,9 +126,15 @@ void menu_add(int menu_number, EFI_STRING menu_name, int menu_type){
     }
 }
 
+void set_cursor(int cursor_x, int cursor_y){
+        gST->ConOut->SetCursorPosition(gST->ConOut, cursor_x, cursor_y);
+}
+
 void clear(){
     gST->ConOut->ClearScreen(gST->ConOut);
 }
+
+
 
 /* menuとして、mikanOSの通常ブートを行う場合はreturnで呼び出し元に処理を戻す */
 EFI_INPUT_KEY poling_key(){

--- a/MikanLoaderPkg/menu.c
+++ b/MikanLoaderPkg/menu.c
@@ -1,0 +1,95 @@
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include  <Library/UefiBootServicesTableLib.h>
+#include "menu.h"
+
+/* EFI_INPUT_KEY poling_key(); */
+void logo_print(int cursor_x, int cursor_y);
+void clear();
+void menu_add(int menu_number, EFI_STRING menu_name, int menu_type);
+void set_cursor(int cursor_x, int cursor_y);
+
+
+void boot_menu();
+
+void boot_menu(){
+    boot_menu_print();
+}
+
+/* メニューに追加を行う場合、ここに画面に表示をするメニューを描く必要があります。*/
+/* menuadd関数にメニューのキーと表示名、メインメニューかOptionメニューか？を追加すれば追加されます、 */
+/* ですが、Optionsは場所が不安定なので、setcursorをいちいちする必要があります。 */
+void boot_menu_print(){
+    clear();
+    logo_print(0, 0);
+    set_cursor(0, 10);
+    Print(L"Hello, Mikan World!\n");
+    set_cursor(0, 11);
+    Print(L"========================================");
+    menu_add(1, L"mikanos boot", 1);
+
+
+    /* Optionの表示 */
+    set_cursor(5, 15);
+    Print(L"Options");
+    set_cursor(5, 16);
+    menu_add(2, L"UEFI information", 2);
+    Print(L"\n========================================\n");    
+}
+
+void set_cursor(int cursor_x, int cursor_y){
+        gST->ConOut->SetCursorPosition(gST->ConOut, cursor_x, cursor_y);
+}
+
+/* menu_typeは1がメインメニュー関連、2がOption関連 */
+/* Optionだとset_cursorをいちいちする必要があります。 */
+void menu_add(int menu_number, EFI_STRING menu_name, int menu_type){
+    if (menu_type == 1){
+        set_cursor(5, 12 + menu_number);
+        Print(L"%d, ", menu_number);
+        Print(L"%s\n", menu_name);
+    } else if (menu_type == 2) {
+        Print(L"%d, ", menu_number);
+        Print(L"%s\n", menu_name);
+    } else {
+        Print(L"bad menu type\n");
+    }
+}
+
+void clear(){
+    gST->ConOut->ClearScreen(gST->ConOut);
+}
+
+/* menuとして、mikanOSの通常ブートを行う場合はreturnで呼び出し元に処理を戻す */
+EFI_INPUT_KEY poling_key(){
+    EFI_INPUT_KEY retkey = {0, 0};
+    EFI_STATUS status;
+    UINTN index = 0;
+
+    /* status = gBS->WaitForEvent(1, &(gST->ConIn->WaitForKey), &index); */
+
+    status = gBS->WaitForEvent(1, &(gST->ConIn->WaitForKey), &index);
+
+    if (!EFI_ERROR(status)) {
+        if (index == 0) {
+            EFI_INPUT_KEY get_key;
+            status = gST->ConIn->ReadKeyStroke(gST->ConIn, &get_key);
+            if (!EFI_ERROR(status)) {
+                retkey = get_key;
+            }
+        }
+    }
+    return retkey;
+}
+
+
+void logo_print(int cursor_x, int cursor_y){
+  gST->ConOut->SetCursorPosition(gST->ConOut, cursor_x, cursor_y);
+  Print(L"                                                                   _____  \n");
+  Print(L"      ___    ___       _   _    _                        ____     / ___ ) \n");
+  Print(L"     /   |  |   \\     |_| | |  / /           _  ___     / __ \\   ( (_     \n");
+  Print(L"    / _  |  |  _ \\     _  | | / /  _____    | |/ _ \\   / /  \\ \\   \\_ \\    \n");
+  Print(L"   / / \\ |  | / \\ \\   | | | |/ /  |  _  |   |  /  \\ \\ | |    | |    \\ \\   \n");
+  Print(L"  / /   \\ \\/ /   \\ \\  | | |  _ \\  | |_|  \\  | |    | | \\ \\__/ /   ___) )  \n");
+  Print(L" /_/     \\__/     \\_\\ |_| |_| \\_\\ |_____|_\\ |_|    |_|  \\____/   (____/   \n");
+}

--- a/MikanLoaderPkg/menu.c
+++ b/MikanLoaderPkg/menu.c
@@ -1,6 +1,6 @@
 #include <Uefi.h>
 #include <Library/UefiLib.h>
-#include  <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiBootServicesTableLib.h>
 #include "menu.h"
 
 EFI_INPUT_KEY poling_key();
@@ -11,12 +11,15 @@ void set_cursor(int cursor_x, int cursor_y);
 void boot_menu();
 void print_device_information();
 void boot_menu_print();
+void print_uefi_information();
+
 
 static EFI_INPUT_KEY get_key = {0, 0};
 
-/* Optionで別画面を開くには、戻ってきた時に再度boot_menu_printをすればいい。 */
+
 void boot_menu(){
     gST->BootServices->SetWatchdogTimer(0, 0, 0, NULL);
+    clear();
     while (1) {
         boot_menu_print();
         get_key = poling_key();
@@ -30,11 +33,23 @@ void boot_menu(){
     }
 }
 
-/*  */
+/* ここに各種情報を記載する */
 void print_device_information(){
     EFI_INPUT_KEY exit_key = {0, 0};
     clear();
-    Print(L"UEFI information \n");
+    print_uefi_information();
+    Print(L"\n\n  Return boot menu: Press q\n");
+    while (1) {
+        exit_key = poling_key();
+        if (exit_key.UnicodeChar == 'q'){
+            clear();
+            return;
+        }
+    }
+}
+
+void print_uefi_information(){
+        Print(L"UEFI information \n");
     Print(L"UEFI Vendor information: %s\n", gST->FirmwareVendor);
     Print(L"UEFI Firmware version: 0x%x\n", gST->FirmwareRevision);
     Print(L"Support UEFI Specification: UEFI");
@@ -79,21 +94,14 @@ void print_device_information(){
         Print(L"%x", gST->Hdr.Revision);
     }
     Print(L"supported\n");
-    set_cursor(1, 15);
-    Print(L"Return boot menu: Press q\n");
-    while (1) {
-        exit_key = poling_key();
-        if (exit_key.UnicodeChar == 'q'){
-            return;
-        }
-    }
 }
 
+
 /* メニューに追加を行う場合、ここに画面に表示をするメニューを描く必要があります。*/
-/* menuadd関数にメニューのキーと表示名、メインメニューかOptionメニューか？を追加すれば追加されます、 */
+/* menuadd関数にメニューのキーと表示名、メインメニュー(1)かOptionメニュー(2)かのフラグを設定すすれば追加されます、 */
 /* ですが、Optionsは場所が不安定なので、setcursorをいちいちする必要があります。 */
 void boot_menu_print(){
-    clear();
+    /* clear(); */
     logo_print(0, 0);
     set_cursor(0, 10);
     Print(L"Hello, Mikan World!\n");
@@ -116,10 +124,10 @@ void boot_menu_print(){
 void menu_add(int menu_number, EFI_STRING menu_name, int menu_type){
     if (menu_type == 1){
         set_cursor(5, 12 + menu_number);
-        Print(L"%d, ", menu_number);
+        Print(L"%d. ", menu_number);
         Print(L"%s\n", menu_name);
     } else if (menu_type == 2) {
-        Print(L"%d, ", menu_number);
+        Print(L"%d. ", menu_number);
         Print(L"%s\n", menu_name);
     } else {
         Print(L"bad menu type\n");
@@ -142,7 +150,6 @@ EFI_INPUT_KEY poling_key(){
     EFI_STATUS status;
     UINTN index = 0;
 
-    /* status = gBS->WaitForEvent(1, &(gST->ConIn->WaitForKey), &index); */
 
     status = gBS->WaitForEvent(1, &(gST->ConIn->WaitForKey), &index);
 

--- a/MikanLoaderPkg/menu.h
+++ b/MikanLoaderPkg/menu.h
@@ -1,0 +1,12 @@
+#include <Uefi.h>
+
+#ifndef _MENU_H_
+#define _MENU_H_
+
+
+
+void boot_menu_print();
+EFI_INPUT_KEY poling_key();
+
+
+#endif

--- a/MikanLoaderPkg/menu.h
+++ b/MikanLoaderPkg/menu.h
@@ -1,12 +1,6 @@
-#include <Uefi.h>
-
 #ifndef _MENU_H_
 #define _MENU_H_
 
-
-
-void boot_menu_print();
-EFI_INPUT_KEY poling_key();
-
+void boot_menu();
 
 #endif


### PR DESCRIPTION
## この機能によるメリット
UEFIで遊ぶ余地ができる他、ブートプロセスで行っているメモリマップ取得をブートメニュー上に移植を行えば、メモリマップ取得を任意で行うことができるようになる可能性。RuntimeServiceの機能を使えば、そこからシャットダウン、再起動を行うことができる可能性が出て来ると考えています。

## 詳細
### 機能
現在MikanOSブートメニューとUEFIのサポート情報などを表示する画面を実装してあります。対応する数字のキーを押すことでメニューの機能が実行されます。

### ロゴに関して
ジェネレーターなどを使うとライセンスなどの影響が出ることを考慮し、テキストエディタで自作しました。

### 右下の余白に関して
ここにはMikanOSのアイコンなどを作成し、おけると思い隙間を作っております。

### watchdogタイマの無効化
bootmenuを表示する関数内で無効化を行っています。
