### PR TITLE
コピー元とコピー先の領域がオーバーラップする可能性がある場合は `memmove` を使うよう修正

### DIFF
--- a/kernel/frame_buffer.cpp
+++ b/kernel/frame_buffer.cpp
@@ -97,6 +97,15 @@ void FrameBuffer::Move(Vector2D<int> dst_pos, const Rectangle<int>& src) {
       dst_buf += bytes_per_scan_line;
       src_buf += bytes_per_scan_line;
     }
+  } else if (dst_pos.y == src.pos.y) { // move left or move right
+    uint8_t* dst_buf = FrameAddrAt(dst_pos, config_);
+    const uint8_t* src_buf = FrameAddrAt(src.pos, config_);
+    for (int y = 0; y < src.size.y; ++y) {
+      // dst_buf and src_buf may overlap, we must use memmove
+      memmove(dst_buf, src_buf, bytes_per_pixel * src.size.x);
+      dst_buf += bytes_per_scan_line;
+      src_buf += bytes_per_scan_line;
+    }
   } else { // move down
     uint8_t* dst_buf = FrameAddrAt(dst_pos + Vector2D<int>{0, src.size.y - 1}, config_);
     const uint8_t* src_buf = FrameAddrAt(src.pos + Vector2D<int>{0, src.size.y - 1}, config_);


### PR DESCRIPTION
[`memcpy(3)`] の引数 `src` と `dst` は `restrict` 修飾されており、オーバーラップする領域を引数として呼び出すことはできません。領域がオーバーラップする場合、未定義動作を引き起こす可能性があります。

[`memcpy(3)`] より:
> The memory areas must not overlap. Use [`memmove(3)`] if the memory areas do overlap. 
> ...
> Failure to observe the requirement that the memory areas do not overlap has been the source of significant bugs. (POSIX and the C standards are explicit that employing memcpy() with overlapping areas produces undefined behavior.)

[`memcpy(3)`]: https://man.archlinux.org/man/memcpy.3
[`memmove(3)`]: https://man.archlinux.org/man/memmove.3

MikanOS の `FrameBuffer::Move` はフレームバッファの特定領域を同一フレームバッファの別の領域にコピーする関数で `memcpy(3)` を使用していますが、コピー元の領域とコピー先の領域の `y` 座標が同じ場合に `memcpy(3)` の引数の `src` と `dst` の示す領域がオーバーラップする可能性がありました。

本 Pull Request では、上記条件 (コピー元の領域とコピー先の領域の `y` 座標が同じ) を満たす場合、 `memmove(3)` を使用するように修正し、未定義動作が発生しないようにしています。