### PR TITLE
ターミナルにてカーソル移動機能を追加

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -328,22 +328,20 @@ Rectangle<int> Terminal::InputKey(
     draw_area.size = window_->InnerSize();
   } else if (ascii == '\b') {
     if (cursor_.x > 1 && show_window_) {
-      for (int i = linebuf_index_;i < linebuf_len_;++i) { // 左にずらしたい
-        linebuf_[i - 1] = linebuf_[i];
-        cursor_.x = i + 1;
-        const auto character = linebuf_[i - 1];
-        FillRectangle(*window_->Writer(), CalcCursorPos(), {8, 16}, {0, 0, 0});
-        WriteAscii(*window_->Writer(), CalcCursorPos(), character, {255, 255, 255});
-      }
-      cursor_.x = linebuf_len_;
-      FillRectangle(*window_->Writer(), CalcCursorPos(), {8, 16}, {0, 0, 0});
-      cursor_.x = linebuf_index_ + 1;
-      --cursor_.x;
-      draw_area.pos = CalcCursorPos();
-
       if (linebuf_index_ > 0) {
         --linebuf_index_;
+        for (int i = linebuf_index_;i < linebuf_len_;++i) { // 左にずらしたい
+          cursor_.x = i + 1; // >のため+1
+          const auto character = linebuf_[i + 1];
+          FillRectangle(*window_->Writer(), CalcCursorPos(), {8, 16}, {0, 0, 0});
+          WriteAscii(*window_->Writer(), CalcCursorPos(), character, {255, 255, 255});
+          linebuf_[i] = linebuf_[i + 1];
+        }
+        cursor_.x = linebuf_len_;
+        FillRectangle(*window_->Writer(), CalcCursorPos(), {8, 16}, {0, 0, 0});
         --linebuf_len_;
+        cursor_.x = 1 + linebuf_index_;
+        draw_area.pos = CalcCursorPos();
       }
     }
   } else if (ascii != 0) {

--- a/kernel/terminal.hpp
+++ b/kernel/terminal.hpp
@@ -57,6 +57,7 @@ class Terminal {
   Vector2D<int> CalcCursorPos() const;
 
   int linebuf_index_{0};
+  int linebuf_len_{0};
   std::array<char, kLineMax> linebuf_{};
   void Scroll1();
 


### PR DESCRIPTION
前のコマンドを少し変更して再利用したい場合や、うっかりコマンドを打ち間ち違えてしまったときに、左右の十字キーでカーソルを移動して編集できたら便利だと思い、実装しました。
ほんの少しだけ、OS開発が加速するかもしれません。
![Screenshot from 2021-09-13 16-40-02](https://user-images.githubusercontent.com/86896657/133043453-2c99357e-c6e6-4a84-98f8-7955397f23b4.png)
