### PR TITLE
メモリ管理で問題が起こる可能性がある

### DIFF
--- a/kernel/memory_manager.cpp
+++ b/kernel/memory_manager.cpp
@@ -110,7 +110,8 @@ void InitializeMemoryManager(const MemoryMap& memory_map) {
     if (available_end < desc->physical_start) {
       memory_manager->MarkAllocated(
           FrameID{available_end / kBytesPerFrame},
-          (desc->physical_start - available_end) / kBytesPerFrame);
+          desc->physical_start / kBytesPerFrame - available_end / kBytesPerFrame + (desc->physical_start % kBytesPerFrame ? 1 : 0)
+      );
     }
 
     const auto physical_end =
@@ -120,7 +121,8 @@ void InitializeMemoryManager(const MemoryMap& memory_map) {
     } else {
       memory_manager->MarkAllocated(
           FrameID{desc->physical_start / kBytesPerFrame},
-          desc->number_of_pages * kUEFIPageSize / kBytesPerFrame);
+          physical_end / kBytesPerFrame - desc->physical_start / kBytesPerFrame + (physical_end % kBytesPerFrame ? 1 : 0)
+      );
     }
   }
   memory_manager->SetMemoryRange(FrameID{1}, FrameID{available_end / kBytesPerFrame});


### PR DESCRIPTION
kUEFIPageSize が kBytesPerFrame よりも細分化されていた場合、
プロセスに対して割り当てるべきでないメモリ領域が割り当てられる可能性があった