### PR TITLE
長さがわかっているデータの出力にPrintToFD関数を使わないようにする

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -489,10 +489,11 @@ void Terminal::ExecuteLine() {
       char u8buf[1024];
       DrawCursor(false);
       while (true) {
-        if (ReadDelim(*fd, '\n', u8buf, sizeof(u8buf)) == 0) {
+        size_t readSize = ReadDelim(*fd, '\n', u8buf, sizeof(u8buf));
+        if (readSize == 0) {
           break;
         }
-        PrintToFD(*files_[1], "%s", u8buf);
+        files_[1]->Write(u8buf, readSize);
       }
       DrawCursor(true);
     }
@@ -567,7 +568,8 @@ void Terminal::ExecuteLine() {
       while (recv_len == 0) {
         recv_len = usb::cdc::driver->ReceiveSerial(buf.data(), send_len);
       }
-      PrintToFD(*files_[1], "%.*s\n", recv_len, buf.data());
+      files_[1]->Write(buf.data(), recv_len);
+      PrintToFD(*files_[1], "\n");
     }();
   } else if (strcmp(command, "setbaud") == 0) {
     [&]{

--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -489,11 +489,11 @@ void Terminal::ExecuteLine() {
       char u8buf[1024];
       DrawCursor(false);
       while (true) {
-        size_t readSize = ReadDelim(*fd, '\n', u8buf, sizeof(u8buf));
-        if (readSize == 0) {
+        size_t read_size = ReadDelim(*fd, '\n', u8buf, sizeof(u8buf));
+        if (read_size == 0) {
           break;
         }
-        files_[1]->Write(u8buf, readSize);
+        files_[1]->Write(u8buf, read_size);
       }
       DrawCursor(true);
     }


### PR DESCRIPTION
fix #39

以下のコマンドにおいて、長さがわかっているデータの出力に `PrintToFD` 関数を使わないようにします。

* `cat`
* `usbtest`

これにより、以下の効果が得られます。

* `PrintToFD` 関数の脆弱性 (`vsprintf` 関数によるバッファオーバーラン) の影響を受けず、長いデータを出力できる
* 値 `0x00` のバイトを含むデータでも出力できる
