### PR TITLE
PrintToFD() がバッファオーバーランしないようにする

### DIFF
--- a/kernel/file.cpp
+++ b/kernel/file.cpp
@@ -12,17 +12,16 @@ size_t PrintToFD(FileDescriptor& fd, const char* format, ...) {
   va_start(ap, format);
   result = vsnprintf(s, BUFFER_SIZE, format, ap);
   va_end(ap);
-  if (result >= BUFFER_SIZE) {
-    int allocateSize = result + 1;
-    std::vector<char> s2(allocateSize);
-    va_start(ap, format);
-    result = vsnprintf(&s2[0], allocateSize, format, ap);
-    va_end(ap);
-    fd.Write(&s2[0], result < allocateSize ? result : allocateSize);
-  } else {
+  if (result < BUFFER_SIZE) {
     fd.Write(s, result);
+    return result;
   }
 
+  std::vector<char> s2(result + 1);
+  va_start(ap, format);
+  vsnprintf(&s2[0], result + 1, format, ap);
+  va_end(ap);
+  fd.Write(&s2[0], result);
   return result;
 }
 

--- a/kernel/file.cpp
+++ b/kernel/file.cpp
@@ -1,17 +1,28 @@
 #include "file.hpp"
 
 #include <cstdio>
+#include <vector>
 
 size_t PrintToFD(FileDescriptor& fd, const char* format, ...) {
+  constexpr int BUFFER_SIZE = 128;
   va_list ap;
   int result;
-  char s[128];
+  char s[BUFFER_SIZE];
 
   va_start(ap, format);
-  result = vsprintf(s, format, ap);
+  result = vsnprintf(s, BUFFER_SIZE, format, ap);
   va_end(ap);
+  if (result >= BUFFER_SIZE) {
+    int allocateSize = result + 1;
+    std::vector<char> s2(allocateSize);
+    va_start(ap, format);
+    result = vsnprintf(&s2[0], allocateSize, format, ap);
+    va_end(ap);
+    fd.Write(&s2[0], result < allocateSize ? result : allocateSize);
+  } else {
+    fd.Write(s, result);
+  }
 
-  fd.Write(s, result);
   return result;
 }
 


### PR DESCRIPTION
* `vsprintf()` のかわりに `vsnprintf()` を用いる
* 結果が長くなる場合、 `std::vector` を用いて領域を動的確保する
