### PR TITLE
fat::FileDescriptor::Write のバグ修正

### DIFF
--- a/kernel/fat.cpp
+++ b/kernel/fat.cpp
@@ -310,7 +310,7 @@ size_t FileDescriptor::Write(const void* buf, size_t len) {
     }
 
     uint8_t* sec = GetSectorByCluster<uint8_t>(wr_cluster_);
-    size_t n = std::min(len, bytes_per_cluster - wr_cluster_off_);
+    size_t n = std::min(len - total, bytes_per_cluster - wr_cluster_off_);
     memcpy(&sec[wr_cluster_off_], &buf8[total], n);
     total += n;
 


### PR DESCRIPTION
書き込みの進捗状況にかかわらず常に最大 `len` バイト書き込もうとしていたのを、  
これまで書き込んだバイト数 `total` も考慮して書き込もうとするバイト数を計算するようにする。

これにより、 #41 で発見したデータが化ける問題を解決する。
