### PR TITLE
add sti to if statement

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -922,6 +922,7 @@ size_t TerminalFileDescriptor::Read(void* buf, size_t len) {
     auto msg = term_.UnderlyingTask().ReceiveMessage();
     if (!msg) {
       term_.UnderlyingTask().Sleep();
+      __asm__("sti");
       continue;
     }
     __asm__("sti");


### PR DESCRIPTION
普段はこのifの中に入ることはありませんが、自分で作った新しいタスクにてterminalから入力を読み取ろうとすると、ここに入って割り込みが永遠に禁止された状態となってしまいます。
ここにif文を作るなら、stiを入れた方が良いと思いました。
レビューのほど、よろしくお願いします。