### PR TITLE
キー操作でマウスを動かせるようにする

### DIFF
--- a/kernel/mouse.cpp
+++ b/kernel/mouse.cpp
@@ -170,6 +170,8 @@ void Mouse::OnInterrupt(uint8_t buttons, int8_t displacement_x, int8_t displacem
   previous_buttons_ = buttons;
 }
 
+Mouse* mouse;
+
 void InitializeMouse() {
   auto mouse_window = std::make_shared<Window>(
       kMouseCursorWidth, kMouseCursorHeight, screen_config.pixel_format);
@@ -180,12 +182,12 @@ void InitializeMouse() {
     .SetWindow(mouse_window)
     .ID();
 
-  auto mouse = std::make_shared<Mouse>(mouse_layer_id);
+  mouse = new Mouse(mouse_layer_id);
   mouse->SetPosition({200, 200});
   layer_manager->UpDown(mouse->LayerID(), std::numeric_limits<int>::max());
 
   usb::HIDMouseDriver::default_observer =
-    [mouse](uint8_t buttons, int8_t displacement_x, int8_t displacement_y) {
+    [](uint8_t buttons, int8_t displacement_x, int8_t displacement_y) {
       mouse->OnInterrupt(buttons, displacement_x, displacement_y);
     };
 

--- a/kernel/mouse.hpp
+++ b/kernel/mouse.hpp
@@ -33,4 +33,6 @@ class Mouse {
   uint8_t previous_buttons_{0};
 };
 
+extern Mouse* mouse;
+
 void InitializeMouse();


### PR DESCRIPTION
キーボードの操作によりマウスカーソルの操作とクリックをできるようにします。  
これにより、USB3.0ポートが1個しかない環境 (LattePandaなど) でもマウスとキーボード両方の操作を(擬似的に)できるようにします。

## 操作方法

Ctrl+Alt を押しながら

* 矢印キー : マウスカーソルの移動
* Enter : 左クリック
* Backspace : 右クリック

クリックは、押しっぱなしにすることでドラッグも可能です。

## 既知の不都合

Ctrl+Alt+矢印キーを約3秒以上押しっぱなしにすると、キーを離しても離したイベントが発生せず、マウスカーソルが移動し続けることがあります。  
同じ方向のキーをもう一度押して離すことで、キーを離したイベントを発生させ、復帰できます。

この「矢印キーをある程度長い間押しっぱなしにすると、離した時に離したイベントが発生しない」現象は、機能追加前のバージョンでも発生するようです。  
(「key push not handled」が出るかどうかでチェックしました)
