### PR TITLE
コマンド実行時のターミナルの描画の改善

### DIFF
--- a/kernel/layer.cpp
+++ b/kernel/layer.cpp
@@ -69,6 +69,7 @@ void LayerManager::SetWriter(FrameBuffer* screen) {
 
 Layer& LayerManager::NewLayer() {
   ++latest_id_;
+  if (latest_id_ == 0) ++latest_id_;
   return *layers_.emplace_back(new Layer{latest_id_});
 }
 

--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -314,6 +314,15 @@ Rectangle<int> Terminal::InputKey(
       ++cursor_.y;
     } else {
       Scroll1();
+      draw_area.pos = ToplevelWindow::kTopLeftMargin;
+      draw_area.size = window_->InnerSize();
+    }
+    if (LayerID()) {
+      Message msg = MakeLayerMessage(
+          task_.ID(), LayerID(), LayerOperation::DrawArea, draw_area);
+      __asm__("cli");
+      task_manager->SendMessage(1, msg);
+      __asm__("sti");
     }
     ExecuteLine();
     Print(">");

--- a/kernel/terminal.hpp
+++ b/kernel/terminal.hpp
@@ -48,7 +48,7 @@ class Terminal {
 
  private:
   std::shared_ptr<ToplevelWindow> window_;
-  unsigned int layer_id_;
+  unsigned int layer_id_{0};
   Task& task_;
 
   Vector2D<int> cursor_{0, 0};


### PR DESCRIPTION
fix #50

ターミナルでのコマンドの実行時、カーソルの移動後コマンド本体の実行開始前にターミナルを再描画します。

これにより、`cat` コマンド、 `hex2bin` コマンド、`large` コマンド (いずれも引数なし) などの実行時、
Enterキーを押しても画面が変わらず、入力が効いていないという誤解を発生させるのを防ぎます。

この誤解により、`cat` コマンドの実行時余計にEnterキーを押してしまい、余計な改行が入ることを誘発する、などの害が考えられます。
