### PR TITLE
ターミナルにおける特殊文字の扱いの改善

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -367,6 +367,18 @@ void Terminal::ExecuteLine() {
   char* redir_char = strchr(&linebuf_[0], '>');
   char* pipe_char = strchr(&linebuf_[0], '|');
   if (first_arg) {
+    if (redir_char && redir_char < first_arg) first_arg = 0;
+    else if (pipe_char && pipe_char < first_arg) first_arg = 0;
+  }
+  if (redir_char && pipe_char) {
+    if (pipe_char < redir_char) {
+      redir_char = 0;
+    } else {
+      PrintToFD(*files_[2], "pipe after redirect is not supported\n");
+      return;
+    }
+  }
+  if (first_arg) {
     *first_arg = 0;
     do {
       ++first_arg;


### PR DESCRIPTION
fix #51

* リダイレクトやパイプを表す文字の後の空白を、引数の開始と認識しなくします。
  * 例えば、 `cat> z.txt` を実行した時、 `z.txt` を入力ではなく出力として扱います。
* リダイレクトとパイプを表す文字が両方ある場合の扱いを改善します。
  * パイプの後にリダイレクトがある場合、(どうせパイプで上書きされるので) リダイレクト用のファイルを開かないようにします。
  * リダイレクトの後にパイプがある場合、Linuxでは後のコマンドには空の標準入力が渡るようですが、今回はエラーにします。

## 既知の不都合

`hex2bin -r | hex2bin > z.txt` を実行すると、入力が受け付けられず固まります。
これは今回の変更を行う前のバージョンでも発生するため、今回の変更による不都合ではないと考えられます。
