### PR TITLE
ファイルの書き込み時に更新日時を更新する

### DIFF
--- a/kernel/fat.hpp
+++ b/kernel/fat.hpp
@@ -171,6 +171,12 @@ DirectoryEntry* AllocateEntry(unsigned long dir_cluster);
  */
 void SetFileName(DirectoryEntry& entry, const char* name);
 
+/** @brief ディレクトリエントリの更新日時を現在時刻にセットする。
+ *
+ * @param entry  更新日時を設定する対象のディレクトリエントリ
+ */
+void SetWriteTimeToCurrent(DirectoryEntry& entry);
+
 /** @brief 指定されたパスにファイルエントリを作成する。
  *
  * @param path  ファイルパス


### PR DESCRIPTION
fix #52

ファイルの書き込み (ファイルの作成 = ディレクトリへの書き込み を含む) 時に、ディレクトリエントリ上の更新日時を更新します。

`ls -l` ( #48 ) において、新たに作成したファイルについても1980年ではなく実際の日時が表示されるようになります。
