### PR TITLE
onlyhltをELF形式にビルドして実行できるようにする

### DIFF
--- a/apps/onlyhlt/.gitignore
+++ b/apps/onlyhlt/.gitignore
@@ -1,1 +1,2 @@
 /onlyhlt
+/onlyhlt.o

--- a/apps/onlyhlt/Makefile
+++ b/apps/onlyhlt/Makefile
@@ -1,7 +1,4 @@
 TARGET = onlyhlt
-
-.PHONY: all
-all: $(TARGET)
-
-onlyhlt: onlyhlt.asm Makefile
-	nasm -f bin -o $@ $<
+OBJS = onlyhlt.o
+include ../Makefile.elfapp
+OBJS = onlyhlt.o

--- a/apps/onlyhlt/onlyhlt.asm
+++ b/apps/onlyhlt/onlyhlt.asm
@@ -1,6 +1,8 @@
 bits 64
 section .text
 
+global _start
+_start:
 loop:
     hlt
     jmp loop


### PR DESCRIPTION
変更前のonlyhltは、機械語のみのファイルがappsディレクトリに置かれており、コマンドを入力すると

```
failed to exec file: kInvalidFile
```

と出てしまい、実行できませんでした。

そこで、他のアプリケーションと同様にELF形式にビルドし、実行できるようにしました。
