### PR TITLE
アプリケーションが終了前に出力をフラッシュするようにする

### DIFF
--- a/apps/cp/cp.cpp
+++ b/apps/cp/cp.cpp
@@ -27,5 +27,6 @@ int main(int argc, char** argv) {
       return 1;
     }
   }
+  fflush(fp_dest);
   return 0;
 }

--- a/apps/grep/grep.cpp
+++ b/apps/grep/grep.cpp
@@ -31,4 +31,5 @@ int main(int argc, char** argv) {
       }
     }
   }
+  fflush(stdout);
 }

--- a/apps/hex2bin/hex2bin.cpp
+++ b/apps/hex2bin/hex2bin.cpp
@@ -102,5 +102,6 @@ int main(int argc, char** argv) {
     }
   }
 
+  fflush(stdout);
   return 0;
 }

--- a/apps/more/more.cpp
+++ b/apps/more/more.cpp
@@ -54,5 +54,6 @@ int main(int argc, char** argv) {
     }
     fputs(lines[i].c_str(), stdout);
   }
+  fflush(stdout);
   return 0;
 }

--- a/apps/sort/sort.cpp
+++ b/apps/sort/sort.cpp
@@ -33,5 +33,6 @@ int main(int argc, char** argv) {
   for (auto& line : lines) {
     printf("%s", line.c_str());
   }
+  fflush(stdout);
   return 0;
 }


### PR DESCRIPTION
`hex2bin` において、6バイトのファイルの16進ダンプが出力されませんでした。
また、`61 62 63` をバイナリに変換しようとすると、0バイトしか出力されませんでした。
これは、改行を出力していないため、出力しようとしたデータが内部のバッファに残ったまま終了してしまうためであると考えられます。
そこで、`fflush()` の呼び出しを追加し、データが最後まで出力されるようにします。

同様に、`cp` コマンドも例えば `NIGHT.BMP` が最後までコピーできなかったので修正します。

さらに、以下のコマンドも、最後に改行が無いファイルを入力すると問題が起こることがあるため、修正します。

* `grep`
* `more`
* `sort`
