### PR TITLE
USB CDCの挙動の改善

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -626,11 +626,13 @@ void Terminal::ExecuteLine() {
       }
 
       std::vector<uint8_t> buf(send_len);
-      int recv_len = usb::cdc::driver->ReceiveSerial(buf.data(), send_len);
-      while (recv_len == 0) {
-        recv_len = usb::cdc::driver->ReceiveSerial(buf.data(), send_len);
+      size_t received_len = 0;
+      while (received_len < send_len) {
+        int recv_len = usb::cdc::driver->ReceiveSerial(buf.data() + received_len,
+                                                       send_len - received_len);
+        received_len += recv_len;
       }
-      files_[1]->Write(buf.data(), recv_len);
+      files_[1]->Write(buf.data(), received_len);
       PrintToFD(*files_[1], "\n");
     }();
   } else if (strcmp(command, "setbaud") == 0) {

--- a/kernel/usb/classdriver/cdc.cpp
+++ b/kernel/usb/classdriver/cdc.cpp
@@ -11,7 +11,7 @@ namespace usb::cdc {
   CDCDriver::CDCDriver(Device* dev, const InterfaceDescriptor* if_comm,
                        const InterfaceDescriptor* if_data)
     : ClassDriver{dev},
-      if_data_index_{if_data->interface_number}
+      if_comm_index_{if_comm->interface_number}
   {
   }
 
@@ -89,7 +89,7 @@ namespace usb::cdc {
     setup_data.request_type.bits.recipient = request_type::kInterface;
     setup_data.request = request::kSetLineCoding;
     setup_data.value = 0;
-    setup_data.index = if_data_index_;
+    setup_data.index = if_comm_index_;
     setup_data.length = sizeof(LineCoding);
 
     line_coding_ = value;

--- a/kernel/usb/classdriver/cdc.hpp
+++ b/kernel/usb/classdriver/cdc.hpp
@@ -129,7 +129,7 @@ namespace usb::cdc {
    private:
     EndpointID ep_interrupt_in_, ep_bulk_in_, ep_bulk_out_;
     std::deque<uint8_t> receive_buf_;
-    uint8_t if_data_index_;
+    uint8_t if_comm_index_;
     LineCoding line_coding_;
   };
 

--- a/kernel/usb/classdriver/cdc.hpp
+++ b/kernel/usb/classdriver/cdc.hpp
@@ -131,6 +131,8 @@ namespace usb::cdc {
     std::deque<uint8_t> receive_buf_;
     uint8_t if_comm_index_;
     LineCoding line_coding_;
+    bool initializing_line_coding_{};
+    uint8_t buf_in_[8];
   };
 
   inline CDCDriver* driver = nullptr;

--- a/kernel/usb/device.cpp
+++ b/kernel/usb/device.cpp
@@ -18,9 +18,11 @@ namespace {
     }
 
     const uint8_t* Next() {
+      if(desc_buf_ + desc_buf_len_ <= p_) return nullptr;
+      const uint8_t* buf = p_;
       p_ += p_[0];
-      if (p_ < desc_buf_ + desc_buf_len_) {
-        return p_;
+      if (p_ <= desc_buf_ + desc_buf_len_) {
+        return buf;
       }
       return nullptr;
     }

--- a/kernel/usb/device.cpp
+++ b/kernel/usb/device.cpp
@@ -121,11 +121,12 @@ namespace {
           if_data = if_desc;
         }
 
-        for (int i = 0; i < if_desc->num_endpoints; ++i) {
+        for (int i = 0; i < if_desc->num_endpoints; ) {
           auto desc = conf_reader.Next();
           if (auto ep_desc = usb::DescriptorDynamicCast<usb::EndpointDescriptor>(desc)) {
             ep_configs.push_back(MakeEPConfig(*ep_desc));
             Log(kWarn, ep_configs.back());
+            ++i;
           } else if (auto cdc = FuncDescDynamicCast<HeaderDescriptor>(desc)) {
             Log(kWarn, "kHeader: cdc=%04x\n", cdc->cdc);
           } else if (auto call = FuncDescDynamicCast<CMDescriptor>(desc)) {


### PR DESCRIPTION
USB CDCの挙動を改善し、 `usbtest` コマンドで公式のArduino UNOのUSB-シリアル変換を通じたシリアル通信ができるようにします。

<details><summary>通信相手 (Arduino) のスケッチ</summary><div>

```c++
void setup() {
  pinMode(13, OUTPUT);
  digitalWrite(13, LOW);
  Serial.begin(9600);
}

bool isHigh = false;

void loop() {
  int c = Serial.read();
  if (c >= 0) {
    Serial.write((c + 1) % 256);
    isHigh = !isHigh;
    digitalWrite(13, isHigh ? HIGH : LOW);
  }
}
```

</div></details>

* `ConfigurationDescriptorReader::Next()` が次のディスクリプタではなく今のディスクリプタを返すようにします。
  * 変更前は、コンフィグレーションディスクリプタが読み飛ばされていました。  
    ここにはインターフェイスディスクリプタの個数などがあり、将来役立つかもしれません。
* 3引数の `NewClassDriver()` において、エンドポイントディスクリプタのみをエンドポイントとして数えるようにします。
  * ファンクショナルディスクリプタを数えないようにし、エンドポイントディスクリプタを規定数読み込んでからループを抜けるようにします。  
    確実にエンドポイントの情報を得られるようになり、またファンクショナルディスクリプタの情報も得られるようになります。
* `CDCDriver::SetLineCoding()` において、 `if_data` ではなく `if_comm` の `interface_number` を用いるようにします。
  * 公式のArduino UNOにおいて、 `setup_data.index` に `1` を入れるとStall Errorとなってしまいましたが、 `0` を入れるとうまく動きそうでした。  
    `if_comm` の `interface_number` が `0` で辻褄が合うので、採用しました。  
    本当に適切かはわかりません。
* 初期化時に通信設定を取得し、ボーレートが0の場合は適当に設定を行うようにします。
  * 初期状態ではシリアル通信が動作しませんでしたが、 `setbaud` コマンドを実行すると動作するようになりました。  
    パケットキャプチャの結果を見ると、最初はGET LINE CODINGの結果が全て0となっていました。  
    そこで、初期化時に通信設定を取得し、ボーレートが0の場合は設定を行うようにすることで、明示的に `setbaud` コマンドを実行しなくても9600bpsで通信できるようにしました。
* 受信を送信とは独立に行い、受信完了時に次の受信を行うようにします。
  * 変更前は、送信時に受信も1回行うようになっていました。  
    送信しないと受信できないというのは不自然だと考え、MikanOSがHIDではどのように受信しているのかを調べたところ、受信完了時に次の受信を行っているようでした。  
    そこで、CDCでも同様に受信完了時に次の受信を行うようにしました。
* `usbtest` コマンドが、送信した長さ分受信するまで受信するようにします。
  * 受信完了のログを出力するとうまく動くようでしたが、ログを出力しないと数文字しか受信できませんでした。  
    これは、変更前の `usbtest` コマンドは正の長さのデータを1回受信できたら受信を打ち切る仕様になっているためであると考えられます。  
    さらに、次の `usbtest` コマンドの実行時に前の `usbtest` コマンドで受信したかったデータが読み込まれ、不自然な挙動となりました。  
    そこで、送信した長さ分受信するまで受信する仕様にすることで、これを改善しました。
