### PR TITLE
新規ファイルの作成時に当該ファイルのDirectoryEntryをゼロクリアする

### DIFF
--- a/kernel/fat.cpp
+++ b/kernel/fat.cpp
@@ -270,8 +270,8 @@ WithError<DirectoryEntry*> CreateFile(const char* path) {
   if (dir == nullptr) {
     return { nullptr, MAKE_ERROR(Error::kNoEnoughMemory) };
   }
+  memset(dir, 0, sizeof(DirectoryEntry));
   fat::SetFileName(*dir, filename);
-  dir->file_size = 0;
   return { dir, MAKE_ERROR(Error::kSuccess) };
 }
 


### PR DESCRIPTION
実機での動作検証において、新しいファイルに書き込む際に #PF が出て動作が止まる現象が発生しました。

![Screenshot 2022-09-19 15-05-48](https://user-images.githubusercontent.com/6667599/191062184-4fbf4d60-262f-481f-966a-60363e0cba1d.png)

検証の結果、この時クラスタ 0xffff0000 に書き込もうとしていることがわかりました。
これは、削除済みエントリに `first_cluster_high` に 0xffff が書き込まれているものが存在し、これを初期化せずに利用するため `FirstCluster()` の上位が 0xffff になることが原因であると考えられます。

![mikanos-directory-20220920](https://user-images.githubusercontent.com/6667599/191062589-d341a2d6-97b5-4100-bc32-78ab930e6322.png)

よって、ファイルの作成時に確保したディレクトリエントリをゼロクリアすることで、意図しないクラスタに書き込まないようにします。
