### PR TITLE
Port::Reset() の実行時にレジスタ port_reset_change をクリアする

### DIFF
--- a/kernel/usb/xhci/port.cpp
+++ b/kernel/usb/xhci/port.cpp
@@ -31,7 +31,7 @@ namespace usb::xhci {
   Error Port::Reset() {
     auto portsc = port_reg_set_.PORTSC.Read();
     portsc.data[0] &= 0x0e00c3e0u;
-    portsc.data[0] |= 0x00020010u; // Write 1 to PR and CSC
+    portsc.data[0] |= 0x00220010u; // Write 1 to PR and CSC and PRC
     port_reg_set_.PORTSC.Write(portsc);
     while (port_reg_set_.PORTSC.Read().bits.port_reset);
     return MAKE_ERROR(Error::kSuccess);


### PR DESCRIPTION
Bmax B2S での検証において、`port_reset_change` が1の状態で `ResetPort()` を実行すると、
`PortStatusChangeEvent` が発生せず、初期化プロセスが止まってしまうことがありました。
この事象が発生すると、`addressing_port` による制御の影響で他のデバイスの初期化もできなくなってしまいます。

そこで、`Port::Reset()` において `port_reset_change` もクリアすることで、
`PortStatusChangeEvent` が発生するようにし、この事象を回避するようにしました。

修正前 (事象の影響でUSBの初期化が止まり、挿している起動用のUSBメモリを認識できていない)

![Screenshot 2022-09-23 01-18-37](https://user-images.githubusercontent.com/6667599/191801201-0ed389ee-4087-4b95-977d-4cb68c771ade.png)

修正後 (事象を回避し、起動用のUSBメモリを認識できている)

![Screenshot 2022-09-23 01-19-59](https://user-images.githubusercontent.com/6667599/191801293-25b740ff-6f32-41be-8614-eba3735024d6.png)
