### PR TITLE
exit コマンドを追加

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -483,6 +483,12 @@ void Terminal::ExecuteLine() {
                     {4, 4}, {8*kColumns, 16*kRows}, {0, 0, 0});
     }
     cursor_.y = 0;
+  } else if (strcmp(command, "exit") == 0) {
+    if (show_window_) {
+      CloseLayer(layer_id_);
+    }
+    __asm__("cli");
+    task_manager->Finish(0);
   } else if (strcmp(command, "lspci") == 0) {
     for (int i = 0; i < pci::num_device; ++i) {
       const auto& dev = pci::devices[i];

--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -487,8 +487,10 @@ void Terminal::ExecuteLine() {
     if (show_window_) {
       CloseLayer(layer_id_);
     }
+    int exit_code = 0;
+    if (first_arg) exit_code = atoi(first_arg);
     __asm__("cli");
-    task_manager->Finish(0);
+    task_manager->Finish(exit_code);
   } else if (strcmp(command, "lspci") == 0) {
     for (int i = 0; i < pci::num_device; ++i) {
       const auto& dev = pci::devices[i];


### PR DESCRIPTION
ターミナルに `exit` コマンドを追加します。
`exit` コマンドを実行すると、実行したターミナルを閉じます。
これにより、例えば、マウスが使えない場合でもキーボードが使えればターミナルを閉じて背景のログを見やすくできるようになります。
